### PR TITLE
Improve page load performance by preloading records

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,7 +4,8 @@ class HomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @accounts ||= current_user.accounts
-    @transactions = current_user.paginated_transactions(page_num: 1)
+    @accounts = current_user.accounts
+    @transactions = current_user.paginated_transactions(page_num: params[:page]&.to_i || 1)
+                                .includes(:account, :plaid_category)
   end
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -8,8 +8,8 @@ class TransactionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @categories ||= PlaidCategory.grouped_by_top_level
     @transactions = current_user.paginated_transactions(page_num: params[:page]&.to_i || 1)
+                                .includes(:account, :plaid_category)
   end
 
   def show

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -51,7 +51,7 @@
                 <tr>
                   <td><%= short_format_date(transaction.date) %></td>
                   <td><%= transaction.description %></td>
-                  <td><%= transaction.plaid_category.detailed_category %></td>
+                  <td><%= humanized_category(transaction.plaid_category) %></td>
                   <td><%= transaction.amount %></td>
                 </tr>
               <% end %>


### PR DESCRIPTION
Include all accounts and categories in the query that we run on page load so that we don't run 100 queries each time.

Closes #52 